### PR TITLE
Proper plugin error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function getExtFromPath(path) {
 }
 
 function getError(txt) {
-    return new PluginError("gulp-free-tex-packer", txt)
+    return new PluginError(appInfo.name, txt)
 }
 
 const SUPPORTED_EXT = ["png", "jpg", "jpeg"];

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function fixPath(path) {
 }
 
 function getExtFromPath(path) {
-	return path.split(".").pop().toLowerCase();
+    return path.split(".").pop().toLowerCase();
 }
 
 function getErrorDescription(txt) {
@@ -17,12 +17,12 @@ function getErrorDescription(txt) {
 
 const SUPPORTED_EXT = ["png", "jpg", "jpeg"];
 
-module.exports = function(options) {
+module.exports = function (options) {
     let files = [];
     let firstFile = null;
 
     function bufferContents(file, enc, cb) {
-		if (file.isNull()) {
+        if (file.isNull()) {
             cb();
             return;
         }
@@ -34,35 +34,35 @@ module.exports = function(options) {
         }
 
         if (!firstFile) firstFile = file;
-		
-		if(SUPPORTED_EXT.indexOf(getExtFromPath(file.relative)) < 0) {
-			cb();
-            return;
-		}
-		
-		files.push({path: fixPath(file.relative), contents: file.contents});
-		
-		cb();
-    }
 
-    function endStream(cb) {
-		if (!files.length) {
+        if (SUPPORTED_EXT.indexOf(getExtFromPath(file.relative)) < 0) {
             cb();
             return;
         }
-        
-        if(!options) options = {};
+
+        files.push({ path: fixPath(file.relative), contents: file.contents });
+
+        cb();
+    }
+
+    function endStream(cb) {
+        if (!files.length) {
+            cb();
+            return;
+        }
+
+        if (!options) options = {};
         options.appInfo = appInfo;
-		
-		texturePacker(files, options, (files) => {
-			for(let item of files) {
-				let file = firstFile.clone({contents: false});
-				file.path = path.join(firstFile.base, item.name);
-				file.contents = item.buffer;
-				this.push(file);
-			}
-			cb();
-		});
+
+        texturePacker(files, options, (files) => {
+            for (let item of files) {
+                let file = firstFile.clone({ contents: false });
+                file.path = path.join(firstFile.base, item.name);
+                file.contents = item.buffer;
+                this.push(file);
+            }
+            cb();
+        });
     }
 
     return through.obj(bufferContents, endStream);

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (options) {
 
         texturePacker(files, options, (files, error) => {
             if (error) {
-                cb(getError(error.description || "Unknown error"));
+                cb(getError(error.message || error.description || "Unknown error"));
                 return;
             }
             for (let item of files) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "free-tex-packer-core": "^0.2.9",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   }
 }


### PR DESCRIPTION
We just had a build fail due to having a too large image for our sprite sheets. I had to spend some time figuring out what was causing it because the error message was quite cryptic:
```
(node:17000) UnhandledPromiseRejectionWarning: TypeError: files is not iterable
    at texturePacker (C:\quicksave\idletowers\client\node_modules\gulp-free-tex-packer\index.js:58:20)
    at packAsync.then.catch (C:\quicksave\idletowers\client\node_modules\free-tex-packer-core\index.js:120:27)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:17000) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:17000) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
Digging into the callstack I noticed that the gulp-free-tex-packer plugin wasn't handling errors from the core properly. This pull request implements error handling using gulp's standard plugin-error package: https://www.npmjs.com/package/plugin-error

With this change the output with the error looks like this:
```
[17:24:58] Error in plugin "gulp-free-tex-packer"
Message:
    Invalid size. Min: 1201x500
```
This is much better even though it would be nicer if the error actually had the filename of the offending file. But that should probably be handled in the core where the error is thrown.

ps. I ran the code through autoformatter because of all the whitespace inconsistencies. The meaningful changes are in the second commit.